### PR TITLE
Add "Below Minimum" Tag

### DIFF
--- a/source/Localization/LocSource.xaml
+++ b/source/Localization/LocSource.xaml
@@ -8,6 +8,7 @@
 	<sys:String x:Key="LOCSystemCheckerRefreshPcInfo">Refresh System Information</sys:String>
 
 	<!-- Game Details View -->
+	<sys:String x:Key="LOCSystemCheckerConfigBelowMinimum">Below Minimum</sys:String>
 	<sys:String x:Key="LOCSystemCheckerConfigMinimum">Minimum</sys:String>
 	<sys:String x:Key="LOCSystemCheckerConfigRecommended">Recommended</sys:String>
 	<sys:String x:Key="LOCSystemCheckerOS">Operating System</sys:String>

--- a/source/Localization/en_US.xaml
+++ b/source/Localization/en_US.xaml
@@ -7,6 +7,7 @@
 	<sys:String x:Key="LOCSystemCheckerRefreshPcInfo">Refresh System Information</sys:String>
 
 	<!-- Game Details View -->
+	<sys:String x:Key="LOCSystemCheckerConfigBelowMinimum">Below Minimum</sys:String>
 	<sys:String x:Key="LOCSystemCheckerConfigMinimum">Minimum</sys:String>
 	<sys:String x:Key="LOCSystemCheckerConfigRecommended">Recommended</sys:String>
 	<sys:String x:Key="LOCSystemCheckerOS">Operating System</sys:String>

--- a/source/Services/SystemCheckerDatabase.cs
+++ b/source/Services/SystemCheckerDatabase.cs
@@ -240,9 +240,6 @@ namespace SystemChecker.Services
 					CheckSystem checkMinimum = SystemApi.CheckConfig(game, item.GetMinimum(), systemConfig, game.IsInstalled);
 					CheckSystem checkRecommended = SystemApi.CheckConfig(game, item.GetRecommended(), systemConfig, game.IsInstalled);
 
-					if (!(checkMinimum.AllOk ?? false) && !(checkRecommended.AllOk ?? false))
-						return false;
-
 					Guid? tagId = ResolveSystemTag(checkMinimum, checkRecommended);
 					if (tagId != null)
 					{
@@ -275,8 +272,8 @@ namespace SystemChecker.Services
 
 		/// <summary>
 		/// Returns the tag ID that best represents the system's compatibility:
-		/// recommended takes priority over minimum.
-		/// Returns <c>null</c> when neither check passes (guard already handled by caller).
+		/// recommended takes priority over minimum, otherwise below minimum.
+		/// May return <c>null</c> if the required tag cannot be found or created.
 		/// </summary>
 		private Guid? ResolveSystemTag(CheckSystem checkMinimum, CheckSystem checkRecommended)
 		{
@@ -290,7 +287,7 @@ namespace SystemChecker.Services
 				return CheckTagExist(ResourceProvider.GetString("LOCSystemCheckerConfigMinimum"));
 			}
 
-			return null;
+			return CheckTagExist(ResourceProvider.GetString("LOCSystemCheckerConfigBelowMinimum"));
 		}
 
 		#endregion


### PR DESCRIPTION
If specs don't meet minimum requirements then ResolveSystemTag will now return a "Below Minimum" tag.

This is then applied to the game like the other two tags, allowing users to filter for games that they don't meet the minimum requirements for.

Closes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced system checker to more accurately identify and report systems that don't meet minimum requirements.
  * Fixed edge case handling when evaluating system status across different requirement levels.

* **Refactor**
  * Improved internal system tag assignment logic to ensure consistent behavior regardless of system state conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->