### PR TITLE
Correct path to SystemChecker hardware configuration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can use the following parameters to filter games:
 
 ### PC Configuration
 
-Open **Settings → Extensions → SystemChecker → Configuration**.
+Open **Settings → Add-ons → Extensions settings → Generic → SystemChecker → Configuration**.
 
 **Detected hardware** (read-only) shows values read from Windows (CPU, GPU, RAM, OS). The plugin uses them automatically for compatibility checks.
 


### PR DESCRIPTION
Unfortunately the playnite menu UI mixes the terms add-ons and extensions as well as having lots of nesting,
but this is the clearer path to find the new hardware configuration tab you added re issue #66

Open **Settings → Add-ons → Extensions settings → Generic → SystemChecker → Configuration**.

instead of 

Open **Settings → Extensions → SystemChecker → Configuration**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to show the current menu path for configuring the SystemChecker plugin in Playnite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->